### PR TITLE
MEN-4301: Integration tests for a failed update

### DIFF
--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,4 @@
+.artifact_modification_lock
+broken_update.ext4
+core-image-full-cmdline-qemux86-64.ext4
+docker_lock

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -19,6 +19,7 @@ docker run --rm --privileged --entrypoint /extract_fs -v $PWD/output:/output \
        mendersoftware/mender-client-qemu:${MENDER_VERSION}
 mv output/* .
 rmdir output
+dd if=/dev/urandom of=broken_update.ext4 bs=10M count=5
 cp core-image-full-cmdline-qemux86-64.ext4 mender_integration/tests
 
 python3 -m pytest -v "$@"

--- a/tests/integration/test_python_api_client.py
+++ b/tests/integration/test_python_api_client.py
@@ -19,7 +19,10 @@ import mender_integration.tests.conftest as cf
 cf.machine_name = "qemux86-64"
 
 from mender_integration.tests.common_setup import standard_setup_one_client_bootstrapped
-from mender_integration.tests.tests.common_update import update_image
+from mender_integration.tests.tests.common_update import (
+    update_image,
+    update_image_failed,
+)
 
 
 def test_update_successful(standard_setup_one_client_bootstrapped):
@@ -42,13 +45,19 @@ def test_update_successful(standard_setup_one_client_bootstrapped):
     )
 
 
-# def test_update_error():
-#     pass
+def test_update_error(standard_setup_one_client_bootstrapped):
+    """Test that the client behaves as expected upon failure.
 
+    This means that the deployment log from both the client itself, and the
+    sub-updater should be uploaded to the Mender server upon an error.
 
-# def test_deployment_logs():
-#     pass
+    """
 
-
-# def test_download_resume():
-#     pass
+    device = standard_setup_one_client_bootstrapped.device
+    update_image_failed(
+        standard_setup_one_client_bootstrapped.device,
+        standard_setup_one_client_bootstrapped.get_virtual_network_host_ip(),
+        install_image="broken_update.ext4",
+        expected_log_message="An update was seemingly in progress, and failed",
+        expected_number_of_reboots=1,
+    )

--- a/tests/integration/yocto/meta-mender-python-client/recipes-mender-python-client/mender-python-client/files/mender-sub-updater
+++ b/tests/integration/yocto/meta-mender-python-client/recipes-mender-python-client/mender-python-client/files/mender-sub-updater
@@ -4,7 +4,14 @@
 #
 # This script is run by the API client through the symlink to /var/lib/mender/install
 
+set -x
+
 MENDER_PYTHON_CLIENT_LOCKFILE=/var/lib/mender/update.lock
+
+msg () {
+  echo >&2 "$@"
+  echo "$@" >> /var/lib/mender/sub-updater.log
+}
 
 program_present () {
   which "$1" || { echo "$1 not found in PATH"; exit 1; }
@@ -16,7 +23,7 @@ program_present "mender-python-client"
 if [[ $# -eq 1 ]]; then
   ARTIFACT_PATH="$1"
   mender install "${ARTIFACT_PATH}" || { ret=$?;\
-                                               echo >&2 "Failed to install the update...";\
+                                               msg "Failed to install the update...";\
                                                mender-python-client report --failure && rm ${MENDER_PYTHON_CLIENT_LOCKFILE}
                                                exit ${ret}; }
   reboot
@@ -26,7 +33,7 @@ else
   ret=$?
   case ${ret} in
     0)
-      echo >&2 "Update successful. Restarting the Mender-Python API client..."
+      msg "Update successful. Restarting the Mender-Python API client..."
       if mender-python-client report --success
       then
         rm ${MENDER_PYTHON_CLIENT_LOCKFILE}
@@ -36,12 +43,22 @@ else
       fi
       ;;
     2)
-      echo >&2 "No update is currently in progress..."
+      msg "No update is currently in progress..."
+      if [ -e /var/lib/mender/update.lock ]; then
+        msg "An update was seemingly in progress, and failed"
+        if ! mender-python-client report --failure
+        then
+          msg "An update failed to apply. And the client failed to report the update. Exit code: $?"
+        else
+          msg "Reported a failed update to the server"
+          msg "Removing the lockfile"
+          rm ${MENDER_PYTHON_CLIENT_LOCKFILE}
+        fi
+      fi
       exit 0
       ;;
     *)
-      echo >&2 "Unexpected 'mender commit' error code ${ret}"
-      # TODO -- Report failure (?)
+      msg "Unexpected 'mender commit' error code ${ret}"
       exit 1
       ;;
   esac


### PR DESCRIPTION
Tests that the client handles:

* Waiting upon an existing lock-file
* Uploads the log from `<datadir>/sub-updater.log`