### PR TITLE
Remove the journal double log entry, and finish off the runner.py sub-updater spawner

### DIFF
--- a/src/mender/mender.py
+++ b/src/mender/mender.py
@@ -120,7 +120,6 @@ def setup_log(args):
         "critical": log.CRITICAL,
     }.get(args.log_level, "info")
     handlers = []
-    handlers.append(log.StreamHandler())
     # TODO - setup this for the device, see:
     # https://docs.python.org/3/library/logging.handlers.html#sysloghandler
     syslogger = log.NullHandler() if args.no_syslog else log.handlers.SysLogHandler()

--- a/src/mender/settings/settings.py
+++ b/src/mender/settings/settings.py
@@ -53,6 +53,8 @@ class Path:
 
         self.lockfile_path = self.data_store + "/update.lock"
 
+        self.install_script = "/usr/share/mender/install"
+
 
 # Global singleton
 PATHS = Path()

--- a/src/mender/statemachine/statemachine.py
+++ b/src/mender/statemachine/statemachine.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 import logging as log
 import os.path
+import sys
 import time
 
 import mender.bootstrap.bootstrap as bootstrap
@@ -299,8 +300,16 @@ class ArtifactInstall(State):
     def run(self, context):
         log.info("Running the ArtifactInstall state...")
         if installscriptrunner.run_sub_updater(context.deployment.ID):
-            return ArtifactReboot()
-        return ArtifactFailure()
+            log.info(
+                "The client has successfully spawned the install-script process. Exiting. Goodbye!"
+            )
+            sys.exit(0)
+            # return ArtifactReboot()
+        log.error(
+            "The daemon should never reach this point. Something is wrong with the setup of the client."
+        )
+        sys.exit(1)
+        # return ArtifactFailure()
 
 
 class UnsupportedState(Exception):
@@ -338,18 +347,8 @@ class ArtifactRollbackReboot(State):
 class ArtifactFailure(State):
     def run(self, context):
         log.info("Running the ArtifactFailure state...")
-        if not deployments.report(
-            context.config.ServerURL,
-            deployments.STATUS_FAILURE,
-            context.deployment.ID,
-            context.config.ServerCertificate,
-            context.JWT,
-            context.deployment_log_handler,
-        ):
-            log.error(
-                "Failed to report the deployment status 'failure' to the Mender server"
-            )
-        return _UpdateDone()
+        # return _UpdateDone()
+        raise UnsupportedState("ArtifactFailure is unhandled by the API client")
 
 
 class _UpdateDone(State):

--- a/support/mender-python-client.service
+++ b/support/mender-python-client.service
@@ -9,6 +9,7 @@ User=root
 Group=root
 ExecStart=/usr/bin/mender-python-client daemon
 Restart=on-failure
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,68 @@
+# Copyright 2021 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging as log
+import os
+import os.path
+import stat
+
+import pytest
+
+import mender.scripts.runner as runner
+import mender.settings.settings as settings
+
+
+@pytest.fixture(autouse=True)
+def set_log_level_info(caplog):
+    """Set the log-level capture to info for all tests"""
+    caplog.set_level(log.INFO)
+
+
+def test_run_sub_updater(monkeypatch, tmpdir):
+    d = tmpdir.mkdir("test_lockfile")
+    lockfile = os.path.join(d, "lockfile.test")
+    install_script = d.join("install")
+    install_script.write("#!/bin/sh echo foo")
+    os.chmod(install_script, stat.S_IRWXU | stat.S_IRWXO | stat.S_IRWXG)
+    with monkeypatch.context() as m:
+        m.setattr(settings.PATHS, "lockfile_path", lockfile)
+        m.setattr(settings.PATHS, "install_script", install_script)
+        assert runner.run_sub_updater("deploymentid-2")
+        assert os.path.exists(lockfile)
+
+
+def test_no_install_script(caplog, monkeypatch, tmpdir):
+    d = tmpdir.mkdir("test_install_script")
+    lockfile = os.path.join(d, "lockfile.test")
+    install_script = os.path.join(d, "install")
+    with monkeypatch.context() as m:
+        m.setattr(settings.PATHS, "lockfile_path", lockfile)
+        m.setattr(settings.PATHS, "install_script", install_script)
+        assert not runner.run_sub_updater("deploymentid-2")
+        assert "No install script found" in caplog.text
+
+
+def test_install_script_permissions(caplog, monkeypatch, tmpdir):
+    d = tmpdir.mkdir("test_install_script")
+    lockfile = os.path.join(d, "lockfile.test")
+    install_script = d.join("install")
+    install_script.write("jibberish")
+    with monkeypatch.context() as m:
+        m.setattr(settings.PATHS, "lockfile_path", lockfile)
+        m.setattr(settings.PATHS, "install_script", install_script)
+        assert not runner.run_sub_updater("deploymentid-2")
+        assert (
+            f"The install script '{settings.PATHS.install_script}' has the wrong permissions"
+            in caplog.text
+        )


### PR DESCRIPTION
* Log fix
* And:

This enables the last missing piece of the mender-python-client, which is the
hand-off to the sub-updater.

This is the last missing piece from the SoW, and so should make the client
feature complete, and barring bugs - ready for handoff.
