### PR TITLE
Remove the yocto layer directories prior to cloning

### DIFF
--- a/tests/integration/yocto/build-script
+++ b/tests/integration/yocto/build-script
@@ -8,9 +8,13 @@ mkdir -p yocto
 
 cd yocto
 
+rm -rf poky
 git clone -b ${YOCTO_BRANCH:-dunfell} https://github.com/mendersoftware/poky
+rm -rf meta-openembedded
 git clone -b ${YOCTO_BRANCH:-dunfell} https://github.com/openembedded/meta-openembedded.git
+rm -rf meta-mender
 git clone -b ${YOCTO_BRANCH:-dunfell} https://github.com/mendersoftware/meta-mender.git
+rm -rf meta-mender-python-client
 cp -r ${script_dir}/meta-mender-python-client .
 
 source poky/oe-init-build-env


### PR DESCRIPTION
Gitlab does actually cache these, and hence this causes the occasional spurious
build-error. Simple removing them prior to cloning fixes it.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>