### PR TITLE
Fix: Race condition in the creation of the RSA key file

### DIFF
--- a/src/mender/bootstrap/bootstrap.py
+++ b/src/mender/bootstrap/bootstrap.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import logging as log
+import os.path
 from typing import Optional
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKeyWithSerialization
@@ -40,6 +41,8 @@ def now(
             private_key = key_already_generated(private_key_path)
         if not private_key:
             log.info("Generating a new RSA key pair..")
+            if force_bootstrap and os.path.exists(private_key_path):
+                os.unlink(private_key_path)
             private_key = key.generate_key()
             key.store_key(private_key, private_key_path)
         log.info("Device bootstrapped successfully")

--- a/src/mender/security/rsa.py
+++ b/src/mender/security/rsa.py
@@ -47,8 +47,9 @@ def store_key(private_key: RSAPrivateKeyWithSerialization, where: str):
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    with open(where, "wb") as key_file:
-        os.chmod(where, 0o0600)
+    with open(
+        os.open(where, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_TRUNC, 0o0600), "wb"
+    ) as key_file:
         key_file.write(pem)
 
 


### PR DESCRIPTION
Previously, the file was opened, and then the permissions were set, opening a
window for a race-condition in which an attacker could open the file in between
the call to `open()`, and the `os.chmod()` call.

The fix is to create the file in one atomic action, using `os.open` as the
argument to `open()`, with the `os.O_EXCL` flag, to hinder any unwanted reads of
the file.