### PR TITLE
RemoteTerminal fixes.

### DIFF
--- a/src/mender/settings/settings.py
+++ b/src/mender/settings/settings.py
@@ -54,7 +54,10 @@ class Path:
 
         self.install_script = "/usr/share/mender/install"
 
-        self.remote_terminal_conf = os.path.join(self.conf, "mender-connect.conf")
+        self.local_remote_terminal_conf = os.path.join(self.conf, "mender-connect.conf")
+        self.global_remote_terminal_conf = os.path.join(
+            self.data_store, "mender-connect.conf"
+        )
 
 
 # Global singleton

--- a/src/mender/statemachine/statemachine.py
+++ b/src/mender/statemachine/statemachine.py
@@ -83,7 +83,8 @@ class Init:
         log.info("Try to load configuration for remote terminal")
         try:
             context.remoteTerminalConfig = config.load(
-                global_path=settings.PATHS.remote_terminal_conf, local_path="",
+                local_path=settings.PATHS.local_remote_terminal_conf,
+                global_path=settings.PATHS.global_remote_terminal_conf,
             )
             log.info(f"Loaded configuration: {context.remoteTerminalConfig}")
         except config.NoConfigurationFileError:


### PR DESCRIPTION
Prevented other user from hijacking the session.
Fixed the threads leaking and the file descriptors leaking.
Enabled reading configuration both from local and global paths.

Changelog: None
Signed-off-by: Marcin Żyrkowski <marcin.zyrkowski@tronel.pl>