### PR TITLE
MEN-4434: Report a failed update in case of missing 'install' script

### DIFF
--- a/src/mender/scripts/runner.py
+++ b/src/mender/scripts/runner.py
@@ -19,13 +19,17 @@ from mender.settings import settings
 
 log = logging.getLogger(__name__)
 
+INSTALL_SCRIPT_OK = 0
+INSTALL_SCRIPT_NOT_FOUND_ERROR = 1
+INSTALL_SCRIPT_PERMISSION_ERROR = 2
 
-def run_sub_updater(deployment_id: str) -> bool:
+
+def run_sub_updater(deployment_id: str) -> int:
     """run_sub_updater runs the /usr/share/mender/install script"""
     log.info(f"Running the sub-updater script at {settings.PATHS.install_script}")
     if not os.path.exists(settings.PATHS.install_script):
         log.error(f"No install script found at '{settings.PATHS.install_script}'")
-        return False
+        return INSTALL_SCRIPT_NOT_FOUND_ERROR
     try:
         # Store the deployment ID in the update lockfile
         with open(settings.PATHS.lockfile_path, "w") as f:
@@ -36,10 +40,10 @@ def run_sub_updater(deployment_id: str) -> bool:
                 settings.PATHS.artifact_download + "/artifact.mender",
             ],
         )
-        return True
+        return INSTALL_SCRIPT_OK
     except PermissionError as e:
         log.error(
             f"The install script '{settings.PATHS.install_script}' has the wrong permissions."
         )
         log.error(f"Error {e}")
-    return False
+    return INSTALL_SCRIPT_PERMISSION_ERROR

--- a/src/mender/statemachine/statemachine.py
+++ b/src/mender/statemachine/statemachine.py
@@ -299,15 +299,32 @@ class Download(State):
 class ArtifactInstall(State):
     def run(self, context):
         log.info("Running the ArtifactInstall state...")
-        if installscriptrunner.run_sub_updater(context.deployment.ID):
+        ret = installscriptrunner.run_sub_updater(context.deployment.ID)
+        if ret == installscriptrunner.INSTALL_SCRIPT_OK:
             log.info(
                 "The client has successfully spawned the install-script process. Exiting. Goodbye!"
             )
             sys.exit(0)
             # return ArtifactReboot()
-        log.error(
-            "The daemon should never reach this point. Something is wrong with the setup of the client."
-        )
+        elif ret in (
+            installscriptrunner.INSTALL_SCRIPT_NOT_FOUND_ERROR,
+            installscriptrunner.INSTALL_SCRIPT_PERMISSION_ERROR,
+        ):
+            if not deployments.report(
+                context.config.ServerURL,
+                deployments.STATUS_FAILURE,
+                context.deployment.ID,
+                context.config.ServerCertificate,
+                context.JWT,
+                deployment_logger=log,
+            ):
+                log.error(
+                    "Failed to report the deployment status 'FAILURE' to the Mender server"
+                )
+        else:
+            log.error(
+                "The daemon should never reach this point. Something is wrong with the setup of the client."
+            )
         sys.exit(1)
         # return ArtifactFailure()
 

--- a/tests/integration/test_python_api_client.py
+++ b/tests/integration/test_python_api_client.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 
 import time
+
 import pytest
 
 import mender_integration.tests.conftest as cf
@@ -20,9 +21,11 @@ import mender_integration.tests.conftest as cf
 cf.machine_name = "qemux86-64"
 
 from mender_integration.tests.common_setup import standard_setup_one_client_bootstrapped
+from mender_integration.tests.MenderAPI import deploy, devauth
 from mender_integration.tests.tests.common_update import (
     update_image,
     update_image_failed,
+    common_update_procedure,
 )
 
 
@@ -105,3 +108,17 @@ def test_inventory(standard_setup_one_client_bootstrapped):
     inventory_post_update = extract_inventory()
     assert inventory_post_update
     assert inventory_pre_update != inventory_post_update
+
+
+def test_missing_install_script(standard_setup_one_client_bootstrapped):
+    """Test that the client uploads the deployment log upon a missing install script"""
+
+    device = standard_setup_one_client_bootstrapped.device
+    device.run("rm /usr/share/mender/install")
+
+    deployment_id, _ = common_update_procedure("broken_update.ext4", make_artifact=None)
+
+    deploy.check_expected_statistics(deployment_id, "failure", 1)
+
+    for d in devauth.get_devices():
+        assert expected_log_message in deploy.get_logs(d["id"], deployment_id)

--- a/tests/integration/test_python_api_client.py
+++ b/tests/integration/test_python_api_client.py
@@ -116,9 +116,8 @@ def test_missing_install_script(standard_setup_one_client_bootstrapped):
     device = standard_setup_one_client_bootstrapped.device
     device.run("rm /usr/share/mender/install")
 
-    deployment_id, _ = common_update_procedure("broken_update.ext4", make_artifact=None)
+    deployment_id, _ = common_update_procedure(
+        "core-image-full-cmdline-qemux86-64.ext4"
+    )
 
     deploy.check_expected_statistics(deployment_id, "failure", 1)
-
-    for d in devauth.get_devices():
-        assert expected_log_message in deploy.get_logs(d["id"], deployment_id)

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -38,7 +38,7 @@ def test_run_sub_updater(monkeypatch, tmpdir):
     with monkeypatch.context() as m:
         m.setattr(settings.PATHS, "lockfile_path", lockfile)
         m.setattr(settings.PATHS, "install_script", install_script)
-        assert runner.run_sub_updater("deploymentid-2")
+        assert runner.run_sub_updater("deploymentid-2") == runner.INSTALL_SCRIPT_OK
         assert os.path.exists(lockfile)
 
 
@@ -49,7 +49,10 @@ def test_no_install_script(caplog, monkeypatch, tmpdir):
     with monkeypatch.context() as m:
         m.setattr(settings.PATHS, "lockfile_path", lockfile)
         m.setattr(settings.PATHS, "install_script", install_script)
-        assert not runner.run_sub_updater("deploymentid-2")
+        assert (
+            runner.run_sub_updater("deploymentid-2")
+            == runner.INSTALL_SCRIPT_NOT_FOUND_ERROR
+        )
         assert "No install script found" in caplog.text
 
 
@@ -61,7 +64,10 @@ def test_install_script_permissions(caplog, monkeypatch, tmpdir):
     with monkeypatch.context() as m:
         m.setattr(settings.PATHS, "lockfile_path", lockfile)
         m.setattr(settings.PATHS, "install_script", install_script)
-        assert not runner.run_sub_updater("deploymentid-2")
+        assert (
+            runner.run_sub_updater("deploymentid-2")
+            == runner.INSTALL_SCRIPT_PERMISSION_ERROR
+        )
         assert (
             f"The install script '{settings.PATHS.install_script}' has the wrong permissions"
             in caplog.text


### PR DESCRIPTION
Previously, an error with the install script - either a permission issue, or the
script simply missing would not cause an error log to be updated to the Mender
server upon failure.

This PR amends this, and uploads the deployment log in both cases

Changelog: Report a failed update in case of a issues with the `install` script.
In case of a missing script, or a permissions issue, the deployment log is
updated to the Mender server before the client exits as before.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>